### PR TITLE
Fixed compatibility with 3.10

### DIFF
--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -204,7 +204,7 @@ class Client:
         """
         self.loop = loop or asyncio.get_running_loop()
         self.logger = logger or log
-        self.lock = (asyncio.Lock() if int(sys.version_info[0]) >= 3 and int(sys.version_info[0]) >= 10 else asyncio.Lock(loop=self.loop))
+        self.lock = (asyncio.Lock() if int(sys.version_info[0]) >= 3 and int(sys.version_info[1]) >= 10 else asyncio.Lock(loop=self.loop))
         self.session = ClientSession()
 
         try:

--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from typing import Optional, Union, Any
 
 from aiohttp import (
@@ -203,7 +204,7 @@ class Client:
         """
         self.loop = loop or asyncio.get_running_loop()
         self.logger = logger or log
-        self.lock = asyncio.Lock(loop=self.loop)
+        self.lock = (asyncio.Lock() if sys.version_info[0] == 3 and sys.version_info[0] >= 10 else asyncio.Lock(loop=self.loop))
         self.session = ClientSession()
 
         try:

--- a/discord/ext/ipc/client.py
+++ b/discord/ext/ipc/client.py
@@ -204,7 +204,7 @@ class Client:
         """
         self.loop = loop or asyncio.get_running_loop()
         self.logger = logger or log
-        self.lock = (asyncio.Lock() if sys.version_info[0] == 3 and sys.version_info[0] >= 10 else asyncio.Lock(loop=self.loop))
+        self.lock = (asyncio.Lock() if int(sys.version_info[0]) >= 3 and int(sys.version_info[0]) >= 10 else asyncio.Lock(loop=self.loop))
         self.session = ClientSession()
 
         try:


### PR DESCRIPTION
In version 3.10 it is no longer necessary to integrate the loop in lock(). 