### PR TITLE
Improvement to getting `attempted_cls`

### DIFF
--- a/discord/ext/ipc/__init__.py
+++ b/discord/ext/ipc/__init__.py
@@ -23,4 +23,5 @@ __author__ = "DaPandaOfficial"
 
 from discord.ext.ipc.client import Client
 from discord.ext.ipc.server import Server
+from discord.ext.ipc.objects import ServerPayload
 from discord.ext.ipc.errors import *

--- a/discord/ext/ipc/objects.py
+++ b/discord/ext/ipc/objects.py
@@ -25,10 +25,6 @@ class ServerPayload:
         self._data = data
         self.lenght = len(data)
         self.endpoint = data["endpoint"]
-        self.__post_init__()
-
-    def __post_init__(self):
-        pass
 
     def __getitem__(self, __k: str):
         return self._data[__k]

--- a/discord/ext/ipc/objects.py
+++ b/discord/ext/ipc/objects.py
@@ -1,16 +1,57 @@
-from typing import Dict, Any
+from typing import Dict, Any, TypeVar
 
-class ServerRequest:
+PT = TypeVar("PT")
+
+
+class ServerPayload:
+    """|class|
+
+    The base class for the payload which is sent to the endpoint
+    when the call is made. This can be subclassed and custom payload
+    can be used. If you do not Typehint the function with the custom
+    payload then it will automatically use this base payload,
+    but keys and values can be accessed like a dictionary or using `X.y`.
+
+    Attributes
+    ----------
+    `lenght`: :class:`int`
+        The lenght of the payload.
+
+    `endpoint`: :class:`str`
+        The endpoint which was called.
+    """
+
     def __init__(self, data: Dict[str, Any]):
-        self._json = data
-        self.length = len(data)
+        self._data = data
+        self.lenght = len(data)
         self.endpoint = data["endpoint"]
-        for key, value in data["data"].items():
-            setattr(self, key, value)
+        self.__post_init__()
 
-    def to_json(self) -> Dict[str, Any]:
-        return self._json
+    def __post_init__(self):
+        pass
+
+    def __getitem__(self, __k: str):
+        return self._data[__k]
+
+    def __contains__(self, __o: object) -> bool:
+        return __o in self._data or __o in self._data.values()
+
+    def __getattribute__(self, __name: str) -> Any:
+        try:
+            return object.__getattribute__(self, __name)
+        except AttributeError:
+            return object.__getattribute__(self, "_data")[__name]
 
     def __repr__(self) -> str:
-        return f"<ServerRequest length={self.length} endpoint={self.endpoint}>"
-    
+        return f"{self.__class__.__name__}(lenght={self.lenght} endpoint='{self.endpoint}')"
+
+    @property
+    def data(self):
+        return self._data
+
+    def items(self):
+        """|method|
+
+        Returns the payload in the form of dictionary items.
+        """
+        return self._data.items()

--- a/discord/ext/ipc/server.py
+++ b/discord/ext/ipc/server.py
@@ -10,6 +10,7 @@ from typing import (
     TypeVar,
     Dict,
     Union,
+    Type,
 )
 from aiohttp import WSMessage
 
@@ -22,7 +23,7 @@ from aiohttp.web import (
 )
 from discord.ext.commands import Bot, AutoShardedBot
 from discord.ext.ipc.errors import *
-from discord.ext.ipc.objects import ServerRequest
+from discord.ext.ipc.objects import ServerPayload
 
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec, TypeAlias
@@ -34,23 +35,6 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-
-def route(name: Optional[str] = None) -> Callable[[RouteFunc], RouteFunc]:
-    """|method|
-    
-    Used to register a coroutine as an endpoint when you don't have
-    access to an instance of class:`~discord.ext.ipc.Server`
-
-    Parameters
-    ----------
-    name: :str:`str`
-        The endpoint name. If not provided the method name will be
-        used.
-    """
-    def decorator(func: RouteFunc) -> RouteFunc:
-        Server.endpoints[name or func.__name__] = func
-        return func
-    return decorator
 
 class Server:
     """|class|
@@ -75,7 +59,7 @@ class Server:
     logger: `logging.Logger`
         A custom logger for all event. Default one is `discord.ext.ipc`
     """
-    endpoints: ClassVar[Dict[str, RouteFunc]] = {}
+    endpoints: ClassVar[Dict[str, Tuple[RouteFunc, Type[ServerPayload]]]] = {}
     _runner = None
     _server = None
     _multicast_server = None
@@ -98,6 +82,10 @@ class Server:
         self.multicast_port = multicast_port
         self.logger = logger
         self.loop = bot.loop 
+
+    def _get_parent(self, func):
+        cls = func.__qualname__.strip(f".{func.__name__}")
+        return self.bot.cogs.get(cls)
 
     def start(self) -> None:
         """
@@ -122,7 +110,8 @@ class Server:
         else:
             self.loop.create_task(self.wait_bot_is_ready())
 
-    def route(self, name: Optional[str] = None) -> Callable[[RouteFunc], RouteFunc]:
+    @classmethod
+    def route(cls, name: Optional[str] = None) -> Callable[[RouteFunc], RouteFunc]:
         """|method|
 
         Used to register a coroutine as an endpoint when you have
@@ -134,7 +123,14 @@ class Server:
             The endpoint name. If not provided the method name will be used.
         """
         def decorator(func: RouteFunc) -> RouteFunc:
-            self.endpoints[name or func.__name__] = func
+            for cls in func.__annotations__.values():
+                if isinstance(cls, ServerPayload):
+                    payload_cls = cls
+                    break
+            else:
+                payload_cls = ServerPayload
+
+            Server.endpoints[name or func.__name__] = (func, payload_cls)
             return func
         return decorator
 
@@ -222,25 +218,19 @@ class Server:
                     "code": 404
                 }
             else:
-                server_response = ServerRequest(request)
-                attempted_cls = None
-
-                for cog in [{cog: [x for x in cog.__dir__() if not x.startswith("__")]} for cog in self.bot.cogs.values()]:
-                    for cog, func in cog.items():
-                        if self.endpoints[endpoint].__name__ in func:
-                            attempted_cls = cog
-                            break
+                endpoint, payload_cls = Server.endpoints.get(endpoint)
+                attempted_cls = self._get_parent(endpoint)
                     
                 if attempted_cls:
-                    arguments = (attempted_cls, server_response)
+                    arguments = (attempted_cls, payload_cls(request))
                 else:
                     # CLient support
-                    arguments = (server_response,)
+                    arguments = (payload_cls(request),)
 
                 self.logger.debug(arguments)
 
                 try:
-                    response = await self.endpoints[endpoint](*arguments)
+                    response = await endpoint(*arguments)
                 except Exception as error:
                     self.logger.error(
                         "Received error while executing %r with %r", endpoint, request,

--- a/discord/ext/ipc/server.py
+++ b/discord/ext/ipc/server.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import warning
+import warnings
 from typing import (
     TYPE_CHECKING, 
     Optional,

--- a/discord/ext/ipc/server.py
+++ b/discord/ext/ipc/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import warning
 from typing import (
     TYPE_CHECKING, 
     Optional,
@@ -34,6 +35,36 @@ if TYPE_CHECKING:
     RouteFunc: TypeAlias = Callable[P, T]
 
 log = logging.getLogger(__name__)
+
+
+def route(name: Optional[str] = None) -> Callable[[RouteFunc], RouteFunc]:
+    """|method|
+
+    Used to register a coroutine as an endpoint when you have
+    access to an instance of :class:`~discord.ext.ipc.Server`
+
+    Parameters
+    ----------
+    name: `str`
+        The endpoint name. If not provided the method name will be used.
+    """
+    warnings.warn(
+        "This function will be deprecated later "
+        "in the future. Consider using `Server.route`."
+    )
+
+    def decorator(func: RouteFunc) -> RouteFunc:
+        for cls in func.__annotations__.values():
+            if isinstance(cls, ServerPayload):
+                payload_cls = cls
+                break
+        else:
+            payload_cls = ServerPayload
+
+        Server.endpoints[name or func.__name__] = (func, payload_cls)
+        return func
+
+    return decorator
 
 
 class Server:


### PR DESCRIPTION
This commit also uses `ServerPayload` instead of Server Request, though the functionality is the same, it has been modified to allow a degree of customization by using [custom payloads](https://github.com/Crussader/better-ipc/blob/6569323702ba5bd3d322eac1ea56f0f00402f334/discord/ext/ipc/objects.py#L6-L53).

It is automatically [handled when annotated](https://github.com/Crussader/better-ipc/blob/6569323702ba5bd3d322eac1ea56f0f00402f334/discord/ext/ipc/server.py#L221-L233), [if not annotated](https://github.com/Crussader/better-ipc/blob/6569323702ba5bd3d322eac1ea56f0f00402f334/discord/ext/ipc/server.py#L113-L135) it will use the default `ServerPayload` class.